### PR TITLE
add current directory to include search path

### DIFF
--- a/ros1_msgs/Makefile
+++ b/ros1_msgs/Makefile
@@ -38,7 +38,7 @@ $(msgs_py_init): $(msgs_py)
 
 # Build an executable that uses locally defined messages
 use_custom_msg: use_custom_msg.cpp $(msgs_cpp)
-	$(CXX) -Wall -o $@ $(geometry_msgs_includes) $(map_msgs_includes) $<
+	$(CXX) -Wall -o $@ $(geometry_msgs_includes) $(map_msgs_includes) -I. $<
 
 # Install everything
 install: all


### PR DESCRIPTION
at least on Ubuntu 15.04 (gcc 4.9.2) I needed to add the current directory to the include search path to be able to include <myproject/Foo.h>
